### PR TITLE
Fixed boids visualisation

### DIFF
--- a/simple_continuous_canvas.js
+++ b/simple_continuous_canvas.js
@@ -104,7 +104,7 @@ var Simple_Continuous_Module = function (canvas_width, canvas_height) {
 
     // Append it to body:
     var canvas = $(canvas_tag)[0];
-    $("#gridwrapper").append(canvas);
+    $("#elements").append(canvas);
 
     // Create the context and the drawing controller:
     var context = canvas.getContext("2d");


### PR DESCRIPTION
The problem was that the file `simple_continuous_canvas.js` was trying to append the boids visualisation canvas to the HTML element with ID "gridwrapper". I guess after updating Mesa that element was no longer present on the page. The other two visualisations mount under the HTML with ID "elements" so I just add to that as well.